### PR TITLE
Add linux_arm64 specific dependency (SSPROD-9138)

### DIFF
--- a/Dockerfile_linux_arm64
+++ b/Dockerfile_linux_arm64
@@ -1,0 +1,14 @@
+FROM golang:1.15 AS builder
+
+ENV OUTPUT_DIR=/out
+
+COPY . /linux-bench
+WORKDIR /linux-bench
+
+RUN GOSUMDB=off CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ${OUTPUT_DIR}/linux-bench .
+RUN cp LICENSE ${OUTPUT_DIR}/LICENSE
+RUN cp README.md ${OUTPUT_DIR}/README.md
+RUN cp -rf cfg ${OUTPUT_DIR}/cfg
+
+WORKDIR /
+RUN rm -rf /linux-bench

--- a/makefile-sysdig
+++ b/makefile-sysdig
@@ -5,12 +5,16 @@ ARTIFACTORY := docker.internal.sysdig.com
 IMAGE_REPO := linux-bench-dependency
 IMAGE_TAG?= dev
 DEPENDENCY_IMAGE_NAME := $(ARTIFACTORY)/$(IMAGE_REPO):$(IMAGE_TAG)
+DEPENDENCY_IMAGE_NAME_linux_arm64 := $(ARTIFACTORY)/$(IMAGE_REPO)_linux_arm64:$(IMAGE_TAG)
 
 build-dependency-image:
 	$(DOCKER) build -t $(DEPENDENCY_IMAGE_NAME) .
+	$(DOCKER) build -t $(DEPENDENCY_IMAGE_NAME_linux_arm64) .
 
 push-dependency-image:
 	$(DOCKER) push $(DEPENDENCY_IMAGE_NAME)
+	$(DOCKER) push $(DEPENDENCY_IMAGE_NAME_linux_arm64)
 
 delete-dependency-image:
 	$(DOCKER) rmi $(DEPENDENCY_IMAGE_NAME)
+	$(DOCKER) rmi $(DEPENDENCY_IMAGE_NAME_linux_arm64)

--- a/makefile-sysdig
+++ b/makefile-sysdig
@@ -9,7 +9,7 @@ DEPENDENCY_IMAGE_NAME_linux_arm64 := $(ARTIFACTORY)/$(IMAGE_REPO)_linux_arm64:$(
 
 build-dependency-image:
 	$(DOCKER) build -t $(DEPENDENCY_IMAGE_NAME) .
-	$(DOCKER) build -t $(DEPENDENCY_IMAGE_NAME_linux_arm64) .
+	$(DOCKER) build -t $(DEPENDENCY_IMAGE_NAME_linux_arm64) -f Dockerfile_linux_arm64 .
 
 push-dependency-image:
 	$(DOCKER) push $(DEPENDENCY_IMAGE_NAME)


### PR DESCRIPTION
Needed to enhance Benchmark Runner to support aarch64 (64-bit ARM) architecture

https://sysdig.atlassian.net/browse/SSPROD-9138