### PR TITLE
chore: Bump Golang to fix vulns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/aquasecurity/linux-bench
 
-go 1.13
+go 1.19
 
 require (
 	github.com/aquasecurity/bench-common v0.4.4
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.1
-	golang.org/x/text v0.3.8 // indirect
+	golang.org/x/text v0.4.0 // indirect
 )


### PR DESCRIPTION
Updates the Golang version and the `text` package version to address vulns. See https://sysdig.atlassian.net/browse/SSPROD-19103 for details.