### PR TITLE
[OP-361] Update golang to 1.24.13 due to vulnerabilities detected by compliance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.3.0
         with:
-          go-version: 1.24.11
+          go-version: 1.24.13
       - name: Checkout code
         uses: actions/checkout@v4.2.2
       - name: Run unit tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.24.11
+          go-version: 1.24.13
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run unit tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.24.11
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run unit tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.11 AS builder
+FROM golang:1.24.13 AS builder
 
 ENV OUTPUT_DIR=/out
 

--- a/Dockerfile_linux_arm64
+++ b/Dockerfile_linux_arm64
@@ -1,4 +1,4 @@
-FROM golang:1.24.11 AS builder
+FROM golang:1.24.13 AS builder
 
 ENV OUTPUT_DIR=/out
 

--- a/Dockerfile_linux_s390x
+++ b/Dockerfile_linux_s390x
@@ -1,4 +1,4 @@
-FROM golang:1.24.11 AS builder
+FROM golang:1.24.13 AS builder
 
 ENV OUTPUT_DIR=/out
 


### PR DESCRIPTION
### Basic info

- **JIRA issue**: https://sysdig.atlassian.net/browse/OP-361

### Description

- Update version to 1.24.13

