### PR TITLE
fix: bump golang 1.25.9 → 1.25.10 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9 AS builder
+FROM golang:1.25.10 AS builder
 
 ENV OUTPUT_DIR=/out
 


### PR DESCRIPTION
## Context

The `compliance-benchmark-runner` image in `draios/secure-backend` embeds the `linux-bench` binary. The current `Dockerfile` uses `golang:1.25.9` which has known CVEs flagged by the Sysdig vulnerability scanner (1 fixable High).

The scanner recommends upgrading to `golang:1.25.10`.

## Change

`golang:1.25.9` → `golang:1.25.10` in `Dockerfile`.

Once this is merged and a new `linux-bench-dependency` image is published, the `LINUX_BENCH_TAG` in `compliance/cmd/benchmark-runner/Dockerfile` (secure-backend) can be bumped to pick up the fix.